### PR TITLE
Only include sysmacros.h on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copyright 2014-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-VERSION = 0.13
+VERSION = 0.14
 GITREF ?= $(VERSION)
 PKG ?= gentoo-functions-$(VERSION)
 

--- a/consoletype.c
+++ b/consoletype.c
@@ -13,7 +13,9 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 
 enum termtype {
 	IS_VT = 0,


### PR DESCRIPTION
sysmacros.h is only needed for `major()` which is only used within an
`#if defined(__linux__)` block. So, this header is only needed on linux.

Bug: https://bugs.gentoo.org/751511